### PR TITLE
Updates system.diagnostic activity guide link

### DIFF
--- a/AspNetCoreMvc/appsettings.json
+++ b/AspNetCoreMvc/appsettings.json
@@ -9,7 +9,7 @@
     // Opt-in for payload submission
     "IncludeRequestPayload": true,
     // Whether to add System.Diagnostics.Activity data to the event::
-    // For more: https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md
+    // For more: https://github.com/dotnet/runtime/blob/master/src/libraries/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md
     "IncludeActivityData": true,
     "Logging": {
       // Record any message with this level or higher as a breadcrumb (default is Information)


### PR DESCRIPTION
Related to my [other PR in `sentry-dotnet`](https://github.com/getsentry/sentry-dotnet/pull/349/).

Noticed that the link does not work anymore. Updated with the new one.